### PR TITLE
Fix various problems with memory allocation

### DIFF
--- a/ClockDomain.h
+++ b/ClockDomain.h
@@ -25,6 +25,8 @@ namespace ClockDomain
 
         Callback(const Callback<ConsumerT,ReturnT> &e) : object(e.object), member(e.member) {}
 
+        virtual ~Callback() {}
+
         ReturnT operator()()
         {
             return (const_cast<ConsumerT*>(object)->*member)();

--- a/DRAMSim.h
+++ b/DRAMSim.h
@@ -36,31 +36,13 @@
  * provide all necessary functionality to talk to an external simulator
  */
 #include "Callback.h"
+#include "MultiChannelMemorySystem.h"
 #include <string>
 using std::string;
 
 namespace DRAMSim 
 {
 
-	class MultiChannelMemorySystem {
-		public: 
-			bool addTransaction(bool isWrite, uint64_t addr);
-			void setCPUClockSpeed(uint64_t cpuClkFreqHz);
-			void update();
-			void printStats(bool finalStats);
-			bool willAcceptTransaction(); 
-			bool willAcceptTransaction(uint64_t addr); 
-			std::ostream &getLogFile();
-
-			void RegisterCallbacks( 
-				TransactionCompleteCB *readDone,
-				TransactionCompleteCB *writeDone,
-				void (*reportPower)(double bgpower, double burstpower, double refreshpower, double actprepower));
-			int getIniBool(const std::string &field, bool *val);
-			int getIniUint(const std::string &field, unsigned int *val);
-			int getIniUint64(const std::string &field, uint64_t *val);
-			int getIniFloat(const std::string &field, float *val);
-	};
 	MultiChannelMemorySystem *getMemorySystemInstance(const string &dev, const string &sys, const string &pwd, const string &trc, unsigned megsOfMemory, std::string *visfilename=NULL);
 }
 

--- a/MultiChannelMemorySystem.cpp
+++ b/MultiChannelMemorySystem.cpp
@@ -46,9 +46,9 @@ using namespace DRAMSim;
 MultiChannelMemorySystem::MultiChannelMemorySystem(const string &deviceIniFilename_, const string &systemIniFilename_, const string &pwd_, const string &traceFilename_, unsigned megsOfMemory_, string *visFilename_, const IniReader::OverrideMap *paramOverrides)
 	:megsOfMemory(megsOfMemory_), deviceIniFilename(deviceIniFilename_),
 	systemIniFilename(systemIniFilename_), traceFilename(traceFilename_),
-	pwd(pwd_), visFilename(visFilename_), 
-	clockDomainCrosser(new ClockDomain::Callback<MultiChannelMemorySystem, void>(this, &MultiChannelMemorySystem::actual_update)),
-	csvOut(new CSVWriter(visDataOut))
+	pwd(pwd_), visFilename(visFilename_),
+	clockDomainCB(new ClockDomain::Callback<MultiChannelMemorySystem, void>(this, &MultiChannelMemorySystem::actual_update)),
+	clockDomainCrosser(clockDomainCB), csvOut(new CSVWriter(visDataOut))
 {
 	currentClockCycle=0; 
 	if (visFilename)
@@ -350,6 +350,9 @@ void MultiChannelMemorySystem::mkdirIfNotExist(string path)
 
 MultiChannelMemorySystem::~MultiChannelMemorySystem()
 {
+	delete csvOut;
+	delete clockDomainCB;
+
 	for (size_t i=0; i<NUM_CHANS; i++)
 	{
 		delete channels[i];

--- a/MultiChannelMemorySystem.h
+++ b/MultiChannelMemorySystem.h
@@ -79,6 +79,7 @@ class MultiChannelMemorySystem : public SimulatorObject
 		string traceFilename;
 		string pwd;
 		string *visFilename;
+		ClockDomain::Callback<MultiChannelMemorySystem, void> *clockDomainCB;
 		ClockDomain::ClockDomainCrosser clockDomainCrosser; 
 		static void mkdirIfNotExist(string path);
 		static bool fileExists(string path); 


### PR DESCRIPTION
- virtual destructor in ClockDomain needed to be able to call
  delete on respective pointers
- do not provide incomplete copy of MultiChannelMemorySystem in
  DRAMSim.h, instead allocate the appropriate header.  Among other
  problems, the copy didn't provide the destructor
- in MultiChannelMemorySystem class, add member clockDomainCB to
  hold pointer to callback.  Pass this to clockDomainCrosser and
  use it to free data structure in destructor
- in MultiChannelMemorySystem destructor delete csvOut as well